### PR TITLE
Fix settings for test target dependencies

### DIFF
--- a/Pile.podspec.json
+++ b/Pile.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Pile",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "summary": "Transition between UIViews with custom animations",
   "homepage": "https://github.com/rechsteiner/Pile",
@@ -10,7 +10,7 @@
   "social_media_url": "http://twitter.com/rechsteiner",
   "source": {
     "git": "https://github.com/rechsteiner/Pile.git",
-    "tag": "v0.2.0"
+    "tag": "v0.2.1"
   },
   "platforms": {
     "ios": "8.0"

--- a/Pile.xcodeproj/project.pbxproj
+++ b/Pile.xcodeproj/project.pbxproj
@@ -238,7 +238,6 @@
 				95884E421B71533E0060C127 /* Frameworks */,
 				95884E431B71533E0060C127 /* Headers */,
 				95884E441B71533E0060C127 /* Resources */,
-				3E5BFE0C1BB98830004BE9C7 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -257,6 +256,7 @@
 				95884E4E1B71533E0060C127 /* Frameworks */,
 				95884E4F1B71533E0060C127 /* Resources */,
 				3E5BFE151BB98EC0004BE9C7 /* Copy Frameworks */,
+				951C696D2044571D0064EDEA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -362,7 +362,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3E5BFE0C1BB98830004BE9C7 /* ShellScript */ = {
+		951C696D2044571D0064EDEA /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Pile will be compatible with the lastest public release of Swift.
 Add the following line to your Podfile and run `pod install`:
 
 ```
-pod Pile', '~> 0.2.0'
+pod Pile', '~> 0.2.1'
 ```
 
 ### [Carthage](https://github.com/Carthage/Carthage)


### PR DESCRIPTION
Quick and Nimble was added as a run script phase to the framework
target instead of the test target, causing build to break.